### PR TITLE
Miglioramenti traduzione plugin 134

### DIFF
--- a/134/8539/res/values-it/strings.xml
+++ b/134/8539/res/values-it/strings.xml
@@ -17,7 +17,7 @@
     <string name="charging">Ricarica</string>
     <string name="charging_in_clean">Ricarica</string>
     <string name="clean">Pulizia</string>
-    <string name="clean_area">"Pulisci l'area"</string>
+    <string name="clean_area">"Area pulita"</string>
     <string name="clean_complete">La pulizia é stata completata</string>
     <string name="clean_complete_msg">"Maestro, ho completato l'obiettivo di pulizia, sono con i miei amici per mostrare loro i frutti del mio lavoro."</string>
     <string name="clean_complete_negative">Completa</string>
@@ -30,14 +30,14 @@
     <string name="clean_history_item_area_symbol">m²</string>
     <string name="clean_history_map_title">Mappa</string>
     <string name="clean_history_month_name">M</string>
-    <string name="clean_history_summary_area_desc">Dettagli area</string>
+    <string name="clean_history_summary_area_desc">Tempo totale</string>
     <string name="clean_history_summary_area_symbol">Metri quadri</string>
-    <string name="clean_history_summary_duration_desc">Dettagli durata</string>
+    <string name="clean_history_summary_duration_desc">Area totale</string>
     <string name="clean_history_summary_hour">Ore</string>
     <string name="clean_history_summary_minute">Minuti</string>
     <string name="clean_history_summary_placeholder">--</string>
-    <string name="clean_history_summary_time">Tempo</string>
-    <string name="clean_history_summary_times_desc">Dettagli tempo</string>
+    <string name="clean_history_summary_time">Avvii</string>
+    <string name="clean_history_summary_times_desc">Avvii totali</string>
     <string name="clean_pause_btn_stop">Fine pulizia</string>
     <string name="clean_pause_dialog_title">Sei sicuro di voler sospendere la pulizia?</string>
     <string name="clean_time">Tempo pulizia</string>
@@ -71,7 +71,7 @@
     <string name="dock_no_map">Nessuna mappa disponibile al momento, il supporto per la ricarica potrebbe non essere trovato.</string>
     <string name="dustbin_filter">Pulisci il contenitore della polvere ed il filtro</string>
     <string name="empty_clean_record">Nessuna cronologia di pulizia</string>
-    <string name="empty_clean_timer">Timer vuoto</string>
+    <string name="empty_clean_timer">Nessuna pianificazione</string>
     <string name="end_time">Orario di termine</string>
     <string name="error">Dettagli errore</string>
     <string name="error_acc">Inclinazione robot</string>
@@ -222,7 +222,7 @@
     <string name="my_robot">Il mio robot</string>
     <string name="net_fail_msg">Connessione di rete scaduta, verifica la rete</string>
     <string name="network_change_message">Utilizzando le reti mobili, il percorso di pulizia in tempo reale consumerà il tuo traffico</string>
-    <string name="no_consult_content">"Dopo l'accensione, il periodo di tempo impostato non eseguirà automaticamente scansionamenti o riprodurrà automaticamente alcuna voce"</string>
+    <string name="no_consult_content">"Durante la fascia oraruia impostata non verranno eseguiti automaticamente scansionamenti e non verrà riprodotta automaticamente alcuna voce"</string>
     <string name="no_consult_end">Orario di fine</string>
     <string name="no_consult_mode">Modalità non disturbare</string>
     <string name="no_consult_start">Orario di inizio</string>
@@ -232,7 +232,7 @@
     <string name="no_next_confirm">Non ricordare la prossima volta</string>
     <string name="no_spot_clean_on_dock">"Si prega di spostare il robot nell'area da pulire e quindi avviare la pulizia locale"</string>
     <string name="normal_content">Equilibrio rumore, potenza di pulizia e durata della batteria</string>
-    <string name="not_in_same_lan_msg">Il robot e il telefono non collegati alla stessa rete, si prega di utilizzare il telecomando dopo aver effettuato il collegamento alla stessa rete.</string>
+    <string name="not_in_same_lan_msg">Il robot e il telefono non sono collegati alla stessa rete, si prega di utilizzare il telecomando dopo aver effettuato il collegamento alla stessa rete.</string>
     <string name="offline">Offline</string>
     <string name="ok">Conferma</string>
     <string name="ok_button">Conferma</string>
@@ -249,8 +249,8 @@
     <string name="picker_minite">M</string>
     <string name="picker_month">M</string>
     <string name="picker_year">A</string>
-    <string name="plug_confirm_abort">Annullare le modifiche</string>
-    <string name="plug_dialog_confirm_abort">Vuoi annullare le modifiche impostate a questo orario?</string>
+    <string name="plug_confirm_abort">Sì</string>
+    <string name="plug_dialog_confirm_abort">Vuoi annullare le modifiche?</string>
     <string name="plug_timer_after">Più tardi</string>
     <string name="plug_timer_after_tomorrow">Dopo domani</string>
     <string name="plug_timer_clear">Rimuovi</string>
@@ -266,7 +266,7 @@
     <string name="plug_timer_off_time">Disattiva timer</string>
     <string name="plug_timer_on">Aperto</string>
     <string name="plug_timer_on_period">Apri sessione</string>
-    <string name="plug_timer_on_time">Attiva timer</string>
+    <string name="plug_timer_on_time">Orario inizio</string>
     <string name="plug_timer_onetime">Esegui una volta</string>
     <string name="plug_timer_repeat">Ripeti</string>
     <string name="plug_timer_saturday">Sabato</string>
@@ -375,7 +375,7 @@
     <string name="timed_clean_cancel">Carica inferiore al 20%, pulizia pianificata annullata</string>
     <string name="timed_clean_end">La pulizia pianificata é stata completata</string>
     <string name="timed_clean_start">La pulizia pianificata é iniziata</string>
-    <string name="timer_add_timer">Aggiungi timer</string>
+    <string name="timer_add_timer">Aggiungi pianificazione</string>
     <string name="timer_clean">Pianifica pulizia</string>
     <string name="timer_clean_mode_old_firmware">Aggiorna il firmware alla versione %1$s o successiva per specificare la modalità di scansione</string>
     <string name="timer_title">Pulizia pianificata</string>


### PR DESCRIPTION
- Modificate alcune voci, sopratutto nella sezione della pianificazione, perché non completamente leggibili (popup piccolo) o per contestualizzarle meglio.

- Nel sommario delle pulizie i nomi delle label "clean_history_summary_area_desc" e "clean_history_summary_duration_desc" sono invertiti.
![img_20171213_092719](https://user-images.githubusercontent.com/10235999/33928962-01c1e5e6-dfe8-11e7-83a5-f4f6fae820b7.png)
